### PR TITLE
build(version): Set @angular peerDeps greater than 11

### DIFF
--- a/just-lightbox/package-lock.json
+++ b/just-lightbox/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "just-lightbox",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.13.0"

--- a/just-lightbox/package.json
+++ b/just-lightbox/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "../node_modules/ng-packagr/package.schema.json",
 	"name": "just-lightbox",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"author": {
 		"name": "Kirill Khrushchöv"
 	},

--- a/just-lightbox/package.json
+++ b/just-lightbox/package.json
@@ -62,10 +62,10 @@
 		"node": ">= 10.13.0"
 	},
 	"peerDependencies": {
-		"@angular/common": ">=11.0.0 <14.0.0",
-		"@angular/core": ">=11.0.0 <14.0.0",
-		"@angular/forms": ">=11.0.0 <14.0.0",
-		"@angular/platform-browser": ">=11.0.0 <14.0.0",
-		"@angular/router": ">=11.0.0 <14.0.0"
+		"@angular/common": ">=11.0.0",
+		"@angular/core": ">=11.0.0",
+		"@angular/forms": ">=11.0.0",
+		"@angular/platform-browser": ">=11.0.0",
+		"@angular/router": ">=11.0.0"
 	}
 }


### PR DESCRIPTION
To avoid to update all time angular as peer dependencies, i set the lower compatible version angular to work with any other version >11